### PR TITLE
feat: ignore nil argument in Panics

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -63,6 +63,7 @@ func AsErr[T Param](t TB, err error, target any, formatAndArgs ...any) {
 }
 
 // Panics asserts that the given function panics with the argument v.
+// If v is nil, the panic argument is ignored.
 func Panics[T Param](t TB, fn func(), v any, formatAndArgs ...any) {
 	t.Helper()
 	defer func() {
@@ -70,7 +71,7 @@ func Panics[T Param](t TB, fn func(), v any, formatAndArgs ...any) {
 		switch r := recover(); {
 		case r == nil:
 			fail[T](t, formatAndArgs, "the function didn't panic")
-		case !reflect.DeepEqual(r, v):
+		case v != nil && !reflect.DeepEqual(r, v):
 			fail[T](t, nil, "panic argument mismatch\ngot:  %v\nwant: %v", r, v)
 		}
 	}()

--- a/assert_test.go
+++ b/assert_test.go
@@ -188,13 +188,19 @@ func TestPanics(t *testing.T) {
 			v:       42,
 			want:    assertCall{helperCalls: 2},
 		},
+		"ok [E] (nil argument)": {
+			fn:      assert.Panics[E],
+			panicFn: func() { panic(42) },
+			v:       nil,
+			want:    assertCall{helperCalls: 2},
+		},
 		"fail [E] (didn't panic)": {
 			fn:      assert.Panics[E],
 			panicFn: func() {},
 			v:       42,
 			want:    assertCall{helperCalls: 3, errorfCalled: true, message: "the function didn't panic"},
 		},
-		"fail [F] (unexpected argument)": {
+		"fail [F] (argument mismatch)": {
 			fn:      assert.Panics[F],
 			panicFn: func() { panic(41) },
 			v:       42,


### PR DESCRIPTION
Rational: starting with Go 1.21, `panic(nil)` is a runtime error.